### PR TITLE
Add batch size in the Constructor.

### DIFF
--- a/src/dalle2/dalle2.py
+++ b/src/dalle2/dalle2.py
@@ -6,8 +6,9 @@ import urllib.request
 import os
 
 class Dalle2():
-    def __init__(self, bearer):
+    def __init__(self, bearer, batch_size):
         self.bearer = bearer
+        self.batch_size = batch_size
 
     def generate(self, promt):
         url = "https://labs.openai.com/api/labs/tasks"
@@ -19,7 +20,7 @@ class Dalle2():
             "task_type": "text2im",
             "prompt": {
                 "caption": promt,
-                "batch_size": 6,
+                "batch_size": self.batch_size,
             }
         }
 


### PR DESCRIPTION
Using 10 as batch size was throwing an issue : 

 "error": {  
"message": "{'task\_type': 'text2im', 'prompt': {'caption': 'portal to another dimension, digital art', 'batch\_size': 10}} is not valid under any of the given schemas",  
"type": "invalid\_request\_error",  
"param": null,  
"code": null  
  }  
}