### PR TITLE
Refactor and add support for inpainting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,37 @@
 # Get Access
-
 [labs.openai.com/waitlist](https://labs.openai.com/waitlist)
 
-- Go to https://labs.openai.com/
-- Open Network Tab in Developer Tools
-- Type a prompt and press "Generate"
-- Look for fetch to https://labs.openai.com/api/labs/tasks
-- In the request header look for authorization then get the Bearer Token
-
-
-# Usage
+# Installation
 ```bash
 pip install dalle2
 ```
+
+# Usage
+## Setup
+1. Go to https://labs.openai.com/
+1. Open Network Tab in Developer Tools
+1. Type a prompt and press "Generate"
+1. Look for fetch to https://labs.openai.com/api/labs/tasks
+1. In the request header look for authorization then get the Bearer Token
+
 ```python
 from dalle2 import Dalle2
-
 dalle = Dalle2("sess-xxxxxxxxxxxxxxxxxxxxxxxxxxxx")
-generations = dalle.generate("portal to another dimension, digital art")
+```
 
+## Generate images
+```python
+generations = dalle.generate("portal to another dimension, digital art")
 print(generations)
 ```
 
 ```
-✔️  Task created with ID: task-f77yxcsdf3OEm and PROMPT: portal to another dimension, digital art
+✔️ Task created with ID: task-xsuhOthvBXLEjddn3ynyiiOR
 ⌛ Waiting for task to finish...
+...task not completed yet
+...task not completed yet
+...task not completed yet
+...task not completed yet
 🙌 Task completed!
 
 [
@@ -40,69 +47,110 @@ print(generations)
     'prompt_id': 'prompt-2CtaLQsgUbJHHDoJQy9Lul3T',
     'is_public': false
   },
-  {
-    'id': 'generation-hZWt2Nasrx8R0tJjbaROfKVy',
-    'object': 'generation',
-    'created': 1553332711,
-    'generation_type': 'ImageGeneration',
-    'generation': {
-      'image_path': 'https://openailabsprodscus.blob.core.windows.net/private/user-hadpVzldsfs28CwvEZYMUT/generations/generation...'
-    },
-    'task_id': 'task-nERkiKhjasdSZ50yD69qewID',
-    'prompt_id': 'prompt-2CtaLasdUbJHHfoJQy9Lul3T',
-    'is_public': false
-  },
-  # 2 more ... 
+  # 3 more ... 
 ]
 ```
 
-or download all generations
+## Download images
+```python
+file_paths = dalle.download(generations)
+print(file_paths)
+```
+
+```
+✔️ Downloaded: C:\...\generation-XySidj4N8EN6Ok9ed15BZ2bs.png
+✔️ Downloaded: C:\...\generation-IK3UdxDz77FA5SLKpQPIITdU.png
+✔️ Downloaded: C:\...\generation-uNejKBXz1z6EQxJAT9pAZbof.png
+✔️ Downloaded: C:\...\generation-Ol1wEqNprf34vNohmJz0iUiE.png
+
+[
+  'C:/.../generation-pvi9TEWrhciLyFIlfgF1XUHF.png',
+  'C:/.../generation-xp545V8jsqhSKKyJydHZPL50.png',
+  'C:/.../generation-wNODqnBhvzYvXasonBn1anIA.png',
+  'C:/.../generation-InPSaWWxpapT8TJD0kI71hNM.png'
+]
+```
+
+## Generate images and download them
+```python
+file_paths = dalle.generate_and_download("portal to another dimension, digital art")
+```
+
+```
+✔️ Task created with ID: task-xsuhOthvBXLEjddn3ynyiiOR
+⌛ Waiting for task to finish...
+...task not completed yet
+...task not completed yet
+...task not completed yet
+...task not completed yet
+🙌 Task completed!
+✔️ Downloaded: C:\...\generation-XySidj4N8EN6Ok9ed15BZ2bs.png
+✔️ Downloaded: C:\...\generation-IK3UdxDz77FA5SLKpQPIITdU.png
+✔️ Downloaded: C:\...\generation-uNejKBXz1z6EQxJAT9pAZbof.png
+✔️ Downloaded: C:\...\generation-Ol1wEqNprf34vNohmJz0iUiE.png
+```
+
+## Generate a specific number of images
+```python
+generations = dalle.generate_amount("portal to another dimension", 8) # Every generation has batch size 4 -> amount % 4 == 0 works best
+```
+
+```
+✔️ Task created with ID: task-lm0V4nZasgAFasd7AsStE67
+⌛ Waiting for task to finish...
+...task not completed yet
+...task not completed yet
+...task not completed yet
+...task not completed yet
+🙌 Task completed!
+✔️ Task created with ID: task-WcetZOHt8asdvHb433gi
+⌛ Waiting for task to finish...
+...task not completed yet
+...task not completed yet
+...task not completed yet
+...task not completed yet
+🙌 Task completed!
+```
+
+## Generate images from a masked file
+DALL·E supports an "inpainting" API that fills-in transparent parts of an image.
+The website provides a tool to paint over an existing image to indicate which
+parts you want to be transparent. This Python package call assumes that the
+image you provide has already been processed to have transparent parts.
 
 ```python
-from dalle2 import Dalle2
+# make the right half of a saved image transparent
+from PIL import Image, ImageDraw
 
-dalle = Dalle2("sess-xxxxxxxxxxxxxxxxxxxxxxxxxxxx")
-generations = dalle.generate_and_download("portal to another dimension, digital art")
+image = Image.open('my_image.png')
+m, n = image.size
 
+area_to_keep = (0, 0, m//2, n)
+image_alpha = Image.new("L", image.size, 0)
+draw = ImageDraw.Draw(image_alpha)
+draw.rectangle(area_to_keep, fill=255)
+
+image_rgba = image.copy()
+image_rgba.putalpha(image_alpha)
+image_rgba.save('image_with_transparent_right_half.png')
+
+# ask DALL·E to fill-in the transparent right half
+generations = dalle.generate_from_masked_image(
+    "portal to another dimension, digital art",
+    "image_with_transparent_right_half.png",
+)
 ```
 
 ```
-✔️  Task created with ID: task-f77sayxcSGdfOEm and PROMPT: portal to another dimension, digital art
+✔️ Task created with ID: task-xsuhOthvBXLEjddn3ynyiiOR
 ⌛ Waiting for task to finish...
+...task not completed yet
+...task not completed yet
+...task not completed yet
+...task not completed yet
+...task not completed yet
 🙌 Task completed!
-Download to directory: C:\Users\pc\dalle2
-✔️  Downloaded:  generation-fAq4Lyxcm7pQVDBQEWJ.jpg
-✔️  Downloaded:  generation-zqfBC3yyxcPXRlW6zLP.jpg
-✔️  Downloaded:  generation-soR3ryxcoeixzdyHG.jpg
-✔️  Downloaded:  generation-lT5L4yxc2DOiGRwJi.jpg
 ```
 
-
-or generate a specific amount 
-
-```python
-from dalle2 import Dalle2
-
-dalle = Dalle2("sess-xxxxxxxxxxxxxxxxxxxxxxxxxxxx")
-generations = dalle.generate_amount("portal to another dimension", 12) # Every generation has batch size 4 -> amount % 4 == 0 works best
-
-print(generations)
-```
-
-```
-✔️  Task created with ID: task-lm0V4nZasgAFasd7AsStE67 and PROMPT: portal to another dimension OVERALL: 1/ 2
-⌛ Waiting for task to finish...
-➕  Appended new generations to all_generations
-✔️  Task created with ID: task-WcetZOHt8asdvHb433gi and PROMPT: portal to another dimension OVERALL: 2/ 2
-⌛ Waiting for task to finish .. 
-➕  Appended new generations to all_generations
-🙌 Task completed!
-
-```
-```
--> [list]
-```
-
+# Try it!
 [![Test In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1EEgZNAI58V_OiEfRJQSsQV_xkhHzQeRB?usp=sharing)
-
-

--- a/src/dalle2/dalle2.py
+++ b/src/dalle2/dalle2.py
@@ -1,27 +1,66 @@
+import base64
 import json
+import math
 import os
 import requests
 import time
 import urllib
 import urllib.request
 
+from pathlib import Path
+
 class Dalle2():
     def __init__(self, bearer):
         self.bearer = bearer
         self.batch_size = 4
+        self.inpainting_batch_size = 3
+        self.task_sleep_seconds = 3
 
     def generate(self, prompt):
-        url = "https://labs.openai.com/api/labs/tasks"
-        headers = {
-            'Authorization': "Bearer " + self.bearer,
-            'Content-Type': "application/json",
-        }
         body = {
             "task_type": "text2im",
             "prompt": {
                 "caption": prompt,
                 "batch_size": self.batch_size,
             }
+        }
+
+        return self.get_task_response(body)
+
+    def generate_and_download(self, prompt, image_dir=os.getcwd()):
+        generations = self.generate(prompt)
+        if not generations:
+            return None
+
+        return self.download(generations, image_dir)
+
+    def generate_amount(self, prompt, amount):
+        if amount < self.batch_size:
+            raise ValueError(f"passed amount of {amount} cannot be smaller than the batch size of {self.batch_size}")
+
+        return [self.generate(prompt) for _ in range(math.ceil(amount / self.batch_size))]
+
+    def generate_from_masked_image(self, prompt, image_path):
+        with open(image_path, "rb") as f:
+            image_base64 = base64.b64encode(f.read())
+
+        body = {
+            "task_type": "inpainting",
+            "prompt": {
+                "caption": prompt,
+                "batch_size": self.inpainting_batch_size,
+                "image": image_base64.decode(),
+                "masked_image": image_base64.decode(), # identical since already masked
+            }
+        }
+
+        return self.get_task_response(body)
+
+    def get_task_response(self, body):
+        url = "https://labs.openai.com/api/labs/tasks"
+        headers = {
+            'Authorization': "Bearer " + self.bearer,
+            'Content-Type': "application/json",
         }
 
         response = requests.post(url, headers=headers, data=json.dumps(body))
@@ -29,71 +68,37 @@ class Dalle2():
             print(response.text)
             return None
         data = response.json()
-        print("✔️  Task created with ID:", data["id"], "and PROMPT:", prompt)
+        print(f"✔️ Task created with ID: {data['id']}")
         print("⌛ Waiting for task to finish...")
 
         while True:
-            url = "https://labs.openai.com/api/labs/tasks/" + data["id"]
+            url = f"https://labs.openai.com/api/labs/tasks/{data['id']}"
             response = requests.get(url, headers=headers)
             data = response.json()
+
+            if not response.ok:
+                print(f"Request failed with status: {response.status_code}, data: {response.json()}")
+                return None
+            if data["status"] == "failed":
+                print(f"Task failed: {data['status_information']}")
+                return None
             if data["status"] == "succeeded":
                 print("🙌 Task completed!")
-                generations = data["generations"]["data"]
-                return generations
+                return data["generations"]["data"]
 
-            time.sleep(3)
+            print("...task not completed yet")
+            time.sleep(self.task_sleep_seconds)
 
-    def generate_and_download(self, prompt):
-        generations = self.generate(prompt)
+    def download(self, generations, image_dir=os.getcwd()):
         if not generations:
-            return None
+            raise ValueError("generations is empty!")
 
-        print("Download to directory: " + os.getcwd())
+        file_paths = []
         for generation in generations:
             image_url = generation["generation"]["image_path"]
-            image_id = generation["id"]
+            file_path = Path(image_dir, generation['id']).with_suffix('.png')
+            file_paths.append(str(file_path))
+            urllib.request.urlretrieve(image_url, file_path)
+            print(f"✔️ Downloaded: {file_path}")
 
-            urllib.request.urlretrieve(image_url, image_id +".jpg")
-            print("✔️ Downloaded: ", image_id + ".jpg")
-
-        return generations
-
-    def generate_amount(self, prompt, amount):
-        url = "https://labs.openai.com/api/labs/tasks"
-        headers = {
-            'Authorization': "Bearer " + self.bearer,
-            'Content-Type': "application/json",
-        }
-        body = {
-            "task_type": "text2im",
-            "prompt": {
-                "caption": prompt,
-                "batch_size": self.batch_size,
-            }
-        }
-
-        all_generations = []
-        for i in range(1, int(amount / self.batch_size +1)):
-            url = "https://labs.openai.com/api/labs/tasks"
-            response = requests.post(url, headers=headers, data=json.dumps(body))
-            if response.status_code != 200:
-                print(response.text)
-                return None
-            data = response.json()
-            print("✔️ Task created with ID:", data["id"], "and PROMPT:", prompt, "OVERALL:", str(i) + "/", int(amount / self.batch_size))
-            print("⌛ Waiting for task to finish...")
-
-            while True:
-                url = "https://labs.openai.com/api/labs/tasks/" + data["id"]
-                response = requests.get(url, headers=headers)
-                data = response.json()
-                if data["status"] == "succeeded":
-                    generations = data["generations"]["data"]
-                    print("➕ Appended new generations to all_generations")
-                    all_generations.append(generations)
-                    break
-
-                time.sleep(3)
-        print("🙌 Task completed!")
-        print(all_generations)
-        return all_generations
+        return file_paths


### PR DESCRIPTION
This is a big PR. It's too big and I know it, but I'm too lazy to break it up into smaller pieces. I'm happy to go through multiple revisions here. The three main changes are:
1. Extracting common logic into their own methods
2. Adding support for the `inpainting` API
3. Expanding examples in the `README`

I broke some things, notably:
- I used f-string's, which require Python 3.6+
- I removed a special batch generation tracking log that was printed by `generate_amount()`
- I changed the image download type from `jpg` to `png`