### PR TITLE
Handle case when request is rejected by Dalle 

### DIFF
--- a/src/dalle2/dalle2.py
+++ b/src/dalle2/dalle2.py
@@ -82,6 +82,9 @@ class Dalle2():
             if data["status"] == "failed":
                 print(f"Task failed: {data['status_information']}")
                 return None
+            if data["status"] == "rejected":
+                print(f"Task rejected: {data['status_information']}")
+                return None
             if data["status"] == "succeeded":
                 print("🙌 Task completed!")
                 return data["generations"]["data"]


### PR DESCRIPTION
Currently if a prompt violates Dalle-2's safety standards, the request will just poll forever until the user ends the task. For example:

```python
from dalle2 import Dalle2

client = Dalle2('sess-XXXXX')

photos = client.generate("Honey badger don't care honey badger don't give a shit")
```

```log
✔️ Task created with ID: task-XXXX
⌛ Waiting for task to finish...
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
...task not completed yet
(etc.)
```

This PR checks for the case when the prompt is rejected so the user doesn't wait forever

```
✔️ Task created with ID: task-XXXX
⌛ Waiting for task to finish...
...task not completed yet
Task rejected: {'type': 'error', 'message': 'Your task failed as a result of our safety system.', 'code': 'task_failed_text_safety_system'}
```